### PR TITLE
Add copy button for code blocks in docs

### DIFF
--- a/docs/execution.md
+++ b/docs/execution.md
@@ -3,7 +3,7 @@ complex computational graphs that consist of
 QM evaluations, model training, and a variety of phase space sampling algorithms, among others.
 If your Python environment contains the required dependencies, you can execute any of the learning examples just like that:
 ```console
-$ python zeolite_reaction.py
+python zeolite_reaction.py
 ```
 Model training, molecular dynamics, and reference evaluations will all get executed in separate processes; the main
 Python script only used to resolve the computational directed acyclic graph (DAG) of tasks.
@@ -34,13 +34,14 @@ To execute the zeolite reaction example not on your local computer, but on remot
 file as an argument__:
 
 ```console
-  $ python my_workflow.py --psiflow-config frontier.py      # executes exact same workflow on Frontier
+python my_workflow.py --psiflow-config frontier.py      # executes exact same workflow on Frontier
 ```
 
 The following sections will explain in more detail how remote execution is configured.
 
 
 !!! note "Parsl execution"
+    
     Before you continue, we recommend going through the 
     [Parsl documentation on execution](https://parsl.readthedocs.io/en/stable/userguide/execution.html)
     first in order to get acquainted with the `executor`, `provider`, and `launcher`

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -47,9 +47,9 @@ Python environment requires barely anything, and is straightforward to install
 using `micromamba` -- a blazingly fast drop-in replacement for `conda`:
 
 ```console
-$ micromamba create -n psiflow_env -c conda-forge -y python=3.9 ndcctools=7.6.1 
-$ micromamba activate psiflow_env
-$ pip install git+https://github.com/molmod/psiflow
+micromamba create -n psiflow_env -c conda-forge -y python=3.9 ndcctools=7.6.1 
+micromamba activate psiflow_env
+pip install git+https://github.com/molmod/psiflow
 ```
 That's it! Before running actual calculations, it is still necessary to set up Parsl
 to use the compute resources you have at your disposal -- whether it's a local GPU,
@@ -57,21 +57,23 @@ a SLURM cluster, or a cloud computing provider; check out the
 [Execution](execution.md) page for more details.
 
 !!! note "Containers 101"
+
     Apptainer -- now the most widely used container system for HPCs -- is part of the
     Linux Foundation and can be installed on Ubuntu using:
 
     ```console
-    $ sudo apt install apptainer
+    sudo apt install apptainer
     ```
 
     Psiflow's containers are hosted on the GitHub Container Registry (GHCR).
     To download and run commands in them, simply execute:
+
     ```console
     # show available pip packages
-    $ apptainer exec oras://ghcr.io/molmod/psiflow:2.0.0-cuda11.8 /usr/local/bin/entry.sh pip list
+    apptainer exec oras://ghcr.io/molmod/psiflow:2.0.0-cuda11.8 /usr/local/bin/entry.sh pip list
 
     # inspect cp2k version
-    $ apptainer exec oras://ghcr.io/molmod/psiflow:2.0.0-cuda11.8 /usr/local/bin/entry.sh cp2k.pmsp --version
+    apptainer exec oras://ghcr.io/molmod/psiflow:2.0.0-cuda11.8 /usr/local/bin/entry.sh cp2k.pmsp --version
     ```
 
     Internally, Apptainer will store the container in a local cache directory such that it does not have to
@@ -117,20 +119,20 @@ over software versions or compiler flags.
 While this is not really necessary in the vast majority of cases, we mention for completeness
 the following manual setup using `micromamba`:
 ```console
-$ CONDA_OVERRIDE_CUDA="11.8" micromamba create -p ./psiflow_env -y -c conda-forge \
+CONDA_OVERRIDE_CUDA="11.8" micromamba create -p ./psiflow_env -y -c conda-forge \
     python=3.9 pip ndcctools=7.6.1 \
     openmm-plumed openmm-torch pytorch=1.13.1=cuda* \
     nwchem py-plumed cp2k && \
     micromamba clean -af --yes
-$ pip install cython==0.29.36 matscipy prettytable && \
+pip install cython==0.29.36 matscipy prettytable && \
     pip install git+https://github.com/molmod/molmod && \
     pip install git+https://github.com/molmod/yaff && \
     pip install e3nn==0.4.4
-$ pip install numpy ase tqdm pyyaml 'torch-runstats>=0.2.0' 'torch-ema>=0.3.0' mdtraj tables
-$ pip install git+https://github.com/acesuit/MACE.git@55f7411 && \
+pip install numpy ase tqdm pyyaml 'torch-runstats>=0.2.0' 'torch-ema>=0.3.0' mdtraj tables
+pip install git+https://github.com/acesuit/MACE.git@55f7411 && \
     pip install git+https://github.com/mir-group/nequip.git@develop --no-deps && \
     pip install git+https://github.com/mir-group/allegro --no-deps && \
     pip install git+https://github.com/svandenhaute/openmm-ml.git@triclinic
-$ pip install git+https://github.com/molmod/psiflow
+pip install git+https://github.com/molmod/psiflow
 ```
 This is mostly a copy-paste from psiflow's [Dockerfile](https://github.com/molmod/psiflow/blob/main/Dockerfile).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,8 @@
 site_name: psiflow
 theme:
   favicon: icon.svg
-  name: material
+  name:
+    material
     #font:
     #  text: overpass
   palette:
@@ -9,6 +10,7 @@ theme:
     accent: teal
   logo: icon.svg
   features:
+    - content.code.copy
     - navigation.instant
     - navigation.tracking
       #- navigation.tabs


### PR DESCRIPTION
This PR adds support for a copy button in the code blocks within the documentation, as described [here](https://squidfunk.github.io/mkdocs-material/reference/code-blocks/#code-selection-button). 

I also removed the `$` symbols from the code blocks, which made it difficult to copy and paste.