### PR TITLE
Add missing imports and remove unused ones

### DIFF
--- a/configs/vsc_hortense.py
+++ b/configs/vsc_hortense.py
@@ -1,5 +1,5 @@
 from parsl.providers import SlurmProvider
-from parsl.launchers import SimpleLauncher
+# from parsl.launchers import SimpleLauncher
 
 from psiflow.execution import (
     Default,

--- a/configs/vsc_stevin.py
+++ b/configs/vsc_stevin.py
@@ -1,5 +1,4 @@
 from parsl.providers import SlurmProvider
-from parsl.launchers import SimpleLauncher
 
 from psiflow.execution import (
     Default,

--- a/examples/mof_phase_transition.py
+++ b/examples/mof_phase_transition.py
@@ -1,7 +1,5 @@
 import requests
-import logging
 from pathlib import Path
-import numpy as np
 
 from ase.io import read
 

--- a/examples/zeolite_reaction.py
+++ b/examples/zeolite_reaction.py
@@ -1,7 +1,5 @@
 import requests
-import logging
 from pathlib import Path
-import numpy as np
 
 from ase.io import read
 

--- a/psiflow/utils.py
+++ b/psiflow/utils.py
@@ -10,6 +10,7 @@ from ase.data import atomic_numbers
 
 from parsl.executors.base import ParslExecutor
 from parsl.app.app import python_app
+from psiflow.data import FlowAtoms, NullState
 from parsl.data_provider.files import File
 from parsl.dataflow.futures import AppFuture
 


### PR DESCRIPTION
1. Add missing imports to `psiflow.utils`
2. Remove unused imports in the config and examples scripts

Closes #12.