### PR TITLE
Update apptainer installation instructions

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -59,10 +59,11 @@ a SLURM cluster, or a cloud computing provider; check out the
 !!! note "Containers 101"
 
     Apptainer -- now the most widely used container system for HPCs -- is part of the
-    Linux Foundation and can be installed on Ubuntu using:
+    Linux Foundation and can be installed on Ubuntu as described in the [official aptainer installation guide](https://apptainer.org/docs/admin/main/installation.html#install-ubuntu-packages). For instance:
 
     ```console
-    sudo apt install apptainer
+    sudo add-apt-repository -y ppa:apptainer/ppa
+    sudo apt install -y apptainer
     ```
 
     Psiflow's containers are hosted on the GitHub Container Registry (GHCR).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -59,12 +59,7 @@ a SLURM cluster, or a cloud computing provider; check out the
 !!! note "Containers 101"
 
     Apptainer -- now the most widely used container system for HPCs -- is part of the
-    Linux Foundation and can be installed on Ubuntu as described in the [official aptainer installation guide](https://apptainer.org/docs/admin/main/installation.html#install-ubuntu-packages). For instance:
-
-    ```console
-    sudo add-apt-repository -y ppa:apptainer/ppa
-    sudo apt install -y apptainer
-    ```
+    Linux Foundation. It is easy to set up on most Linux distributions, as explained in the [Apptainer documentation](https://apptainer.org/docs/admin/main/installation.html#install-ubuntu-packages).
 
     Psiflow's containers are hosted on the GitHub Container Registry (GHCR).
     To download and run commands in them, simply execute:


### PR DESCRIPTION
Closes #9.

The [apptainer guide](https://apptainer.org/docs/admin/main/installation.html#install-ubuntu-packages) suggests:

```bash
sudo apt update
sudo apt install -y software-properties-common
sudo add-apt-repository -y ppa:apptainer/ppa
sudo apt update
sudo apt install -y apptainer
```

which worked for me. I'm not sure if you want the full block though. Right now, I linked to the official docs and included the missing `sudo add-apt-repository -y ppa:apptainer/ppa`. But one could argue that the full example above should be included.