### PR TITLE
Add `isort` section to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,9 @@ max-line-length = 88
 extend-ignore = ["E203", "E501", "E704"]
 #select = C,E,F,W,B,B950
 
+[tool.isort]
+profile = 'black'
+skip_gitignore = true
 
 [tool.pytest.ini_options]
 log_cli = 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ extend-ignore = ["E203", "E501", "E704"]
 #select = C,E,F,W,B,B950
 
 [tool.isort]
-profile = 'black'
+profile = "black"
 
 [tool.pytest.ini_options]
 log_cli = 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ extend-ignore = ["E203", "E501", "E704"]
 
 [tool.isort]
 profile = 'black'
-skip_gitignore = true
 
 [tool.pytest.ini_options]
 log_cli = 0


### PR DESCRIPTION
Since `isort` and `black` can sometimes conflict with one another, I added the following which will ensure they don't. This is recommended [here](https://pycqa.github.io/isort/docs/configuration/black_compatibility.html).

```
[tool.isort]
profile = "black"
```