### PR TITLE
Create symlinks into psiflow_internal directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,9 @@ dmypy.json
 
 pytest-tmp/
 wandb/
+
+# psiflow internal and its symlinks
+psiflow_internal/
+psiflow_log
+psiflow_submit_scripts
+psiflow_task_logs


### PR DESCRIPTION
see #54 

Turn off with  `make_symlinks: False` in psiflow config.
Also removed option to supply custom path (fixed to `psiflow_internal` \)