### PR TITLE
Make client wait for socket to appear

### DIFF
--- a/psiflow/sampling/client.py
+++ b/psiflow/sampling/client.py
@@ -2,6 +2,22 @@
 import os
 
 
+class SocketNotFoundException(Exception):
+    pass
+
+
+def wait_for_socket(address: 'Path', timeout: float = 10, interval: float = 0.1) -> None:
+    """"""
+    import time
+    while not address.exists():
+        time.sleep(interval)
+        timeout -= interval
+        print(timeout)
+        if timeout < 0:
+            raise SocketNotFoundException(f'Could not find socket "{address}" to connect to..')
+    return
+
+
 def main():
     import argparse
     import time
@@ -73,18 +89,22 @@ def main():
 
     affinity = os.sched_getaffinity(os.getpid())
     print("CPU affinity after function init: {}".format(affinity))
-
     try:
         t0 = time.time()
-        function([template] * 10)  # torch warmp-up before simulation
+        function([template] * 10)  # torch warm-up before simulation
         print("time for 10 evaluations: {}".format(time.time() - t0))
+        socket_address = Path.cwd() / args.address
+        wait_for_socket(socket_address)
         run_driver(
             unix=True,
-            address=str(Path.cwd() / args.address),
+            address=str(socket_address),
             driver=driver,
             sockets_prefix="",
         )
     except ForceMagnitudeException as e:
-        print(e)  # induce timeout in server
-    except ConnectionResetError as e:  # some other client induced a timeout
+        print(e)                                                # induce timeout in server
+    except ConnectionResetError as e:                           # some other client induced a timeout
         print(e)
+    except SocketNotFoundException as e:
+        print(e, *list(Path.cwd().iterdir()), sep='\n')         # server-side socket not found
+

--- a/psiflow/sampling/client.py
+++ b/psiflow/sampling/client.py
@@ -12,7 +12,6 @@ def wait_for_socket(address: 'Path', timeout: float = 10, interval: float = 0.1)
     while not address.exists():
         time.sleep(interval)
         timeout -= interval
-        print(timeout)
         if timeout < 0:
             raise SocketNotFoundException(f'Could not find socket "{address}" to connect to..')
     return

--- a/psiflow/sampling/sampling.py
+++ b/psiflow/sampling/sampling.py
@@ -393,7 +393,6 @@ def _execute_ipi(
         cd_command,
         write_command,
         command_start,
-        "sleep 3s;",
         command_clients,
         "wait;",
         command_end,


### PR DESCRIPTION
Replaces the hardcoded `sleep 3s` between I-PI `server` and `client` startup. #74 