### PR TITLE
Option to set atomic masses in walkers

### DIFF
--- a/psiflow/geometry.py
+++ b/psiflow/geometry.py
@@ -370,6 +370,16 @@ class Geometry:
             return np.nan
         else:
             return np.linalg.det(self.cell)
+        
+    @property
+    def atomic_masses(self):
+         """
+         Get the atomic masses of the atoms in the geometry.
+ 
+         Returns:
+             np.ndarray: Array of atomic masses.
+         """
+         return np.array([atomic_masses[n] for n in self.per_atom.numbers])
 
     @classmethod
     def from_data(

--- a/psiflow/sampling/sampling.py
+++ b/psiflow/sampling/sampling.py
@@ -240,6 +240,11 @@ def setup_system_template(
     else:
         velocities.text = " 300 "
     initialize.append(velocities)
+    if walkers[0].masses is not None:
+        masses = ET.Element("masses", mode="manual")
+        amu = 1822.8885  # amu in atomic units
+        masses.text = str(list(walkers[0].masses * amu)).replace("[", "[ ").replace("]", " ]")  # replace str(list()) with np.array_str()?
+        initialize.append(masses)
 
     system = ET.Element("system", prefix="walker-INDEX")
     system.append(initialize)

--- a/psiflow/sampling/sampling.py
+++ b/psiflow/sampling/sampling.py
@@ -241,9 +241,10 @@ def setup_system_template(
         velocities.text = " 300 "
     initialize.append(velocities)
     if walkers[0].masses is not None:
+        import ase.units
+        AMU_TO_AU = ase.units._amu / ase.units._me
         masses = ET.Element("masses", mode="manual")
-        amu = 1822.8885  # amu in atomic units
-        masses.text = str(list(walkers[0].masses * amu)).replace("[", "[ ").replace("]", " ]")  # replace str(list()) with np.array_str()?
+        masses.text = str(list(walkers[0].masses * AMU_TO_AU)).replace("[", "[ ").replace("]", " ]")  # replace str(list()) with np.array_str()?
         initialize.append(masses)
 
     system = ET.Element("system", prefix="walker-INDEX")

--- a/psiflow/sampling/walker.py
+++ b/psiflow/sampling/walker.py
@@ -49,6 +49,7 @@ class Walker:
     state: Union[Geometry, AppFuture, None]
     temperature: Optional[float]
     pressure: Optional[float]
+    masses: Union[np.ndarray, float, None]
     nbeads: int
     timestep: float
     coupling: Optional[Coupling]
@@ -62,6 +63,7 @@ class Walker:
         state: Union[Geometry, AppFuture, None] = None,
         temperature: Optional[float] = 300,
         pressure: Optional[float] = None,
+        masses: Union[np.ndarray, float, None] = None,
         nbeads: int = 1,
         timestep: float = 0.5,
         metadynamics: Optional[Metadynamics] = None,
@@ -80,6 +82,13 @@ class Walker:
 
         self.temperature = temperature
         self.pressure = pressure
+
+        if isinstance(masses, (float, int)):
+            masses *= self.start.atomic_masses
+        self.masses = masses
+        if self.masses is not None:
+            assert len(self.masses) == len(self.start), "Masses do not match number of atoms"
+
         self.nbeads = nbeads
         self.timestep = timestep
 
@@ -108,6 +117,7 @@ class Walker:
                 state=self.state,
                 temperature=self.temperature,
                 pressure=self.pressure,
+                masses=self.masses,
                 nbeads=self.nbeads,
                 timestep=self.timestep,
                 metadynamics=metadynamics,


### PR DESCRIPTION
Added `masses` argument to the `Walker`-class. If a `float` is provided, the atomic masses from ASE are scaled by this value. Individual atomic masses can be set by providing a `list` containing a value for each atom in the system. It doesn't look like units can be provided in i-Pi for atomic masses, therefore atomic mass units are expected and these are converted to internal i-Pi units automatically.