### PR TITLE
Support for Psiflow driver in i-Pi

### DIFF
--- a/psiflow/sampling/utils.py
+++ b/psiflow/sampling/utils.py
@@ -101,3 +101,14 @@ class FunctionDriver:
         extras = ""
 
         return pot_ipi, force_ipi, vir_ipi, extras
+
+
+def initialise_driver(driver) -> None:
+    """This function does not do anything yet. Stay tuned."""
+    pass
+
+
+def check_output(data: dict) -> None:
+    """This function does not do anything yet. Stay tuned."""
+    pass
+


### PR DESCRIPTION
Minor adaptation to support the Psiflow PES driver we are integrating into i-Pi.

see #85 and [`driver`](https://github.com/armaet/i-pi)