### PR TITLE
Replica exchange Hamiltonian swaps as bias

### DIFF
--- a/psiflow/free_energy/phonons.py
+++ b/psiflow/free_energy/phonons.py
@@ -16,9 +16,7 @@ from psiflow.geometry import Geometry, mass_weight
 from psiflow.hamiltonians import Hamiltonian, MixtureHamiltonian
 from psiflow.sampling.sampling import (
     setup_sockets,
-    label_forces,
     make_force_xml,
-    serialize_mixture,
     make_start_command,
     make_client_command
 )
@@ -139,7 +137,7 @@ def compute_harmonic(
     energy_shift: float = 0.00095,
 ) -> AppFuture:
     hamiltonian: MixtureHamiltonian = 1 * hamiltonian
-    names = label_forces(hamiltonian)
+    names = hamiltonian.get_named_components()
     sockets = setup_sockets(names)
     forces = make_force_xml(hamiltonian, names)
 
@@ -175,7 +173,7 @@ def compute_harmonic(
         input_future,
         Dataset([state]).extxyz,
     ]
-    inputs += serialize_mixture(hamiltonian, dtype="float64")
+    inputs += hamiltonian.serialize(dtype="float64")
 
     client_args = []
     for name in names:

--- a/psiflow/hamiltonians.py
+++ b/psiflow/hamiltonians.py
@@ -58,7 +58,7 @@ class Hamiltonian(Computable):
     def __eq__(self, hamiltonian: Hamiltonian) -> bool:
         raise NotImplementedError
 
-    def __mul__(self, a: float) -> Hamiltonian:
+    def __mul__(self, a: float) -> MixtureHamiltonian:
         return MixtureHamiltonian([self], [a])
 
     def __add__(self, hamiltonian: Hamiltonian) -> Hamiltonian:
@@ -106,6 +106,9 @@ class Zero(Hamiltonian):
 
     def __add__(self, hamiltonian: Hamiltonian) -> Hamiltonian:
         return hamiltonian          # (Zero + Hamiltonian) is different from (Hamiltonian + Zero)
+
+    __rmul__ = __mul__  # handle float * Zero
+
 
 
 @typeguard.typechecked
@@ -161,6 +164,8 @@ class MixtureHamiltonian(Hamiltonian):
             self.hamiltonians,
             [c * a for c in self.coefficients],
         )
+
+    __rmul__ = __mul__  # handle float * MixtureHamiltonian
 
     def __len__(self) -> int:
         return len(self.coefficients)
@@ -223,6 +228,9 @@ class MixtureHamiltonian(Hamiltonian):
             names.append(f"{name}{counts[name]}")
             counts[name] += 1
         return names
+
+    def serialize(self, **kwargs) -> list[DataFuture]:
+        return [h.serialize_function(**kwargs) for h in self.hamiltonians]
 
 
 @typeguard.typechecked

--- a/psiflow/hamiltonians.py
+++ b/psiflow/hamiltonians.py
@@ -35,7 +35,7 @@ from psiflow.utils.io import dump_json
 class Hamiltonian(Computable):
     outputs: ClassVar[tuple] = ("energy", "forces", "stress")
     batch_size = 1000
-    app: Callable
+    app: ClassVar[Callable]             # TODO: app is actually an instance variable, but serialization complains..
     function_name: ClassVar[str]
 
     def compute(

--- a/psiflow/hamiltonians.py
+++ b/psiflow/hamiltonians.py
@@ -64,9 +64,8 @@ class Hamiltonian(Computable):
     def __add__(self, hamiltonian: Hamiltonian) -> Hamiltonian:
         if type(hamiltonian) is Zero:
             return self
-        if type(hamiltonian) is MixtureHamiltonian:
-            return hamiltonian.__add__(self)
-        return MixtureHamiltonian([self, hamiltonian], [1., 1.])
+        mixture = MixtureHamiltonian([self], [1.])
+        return mixture.__add__(hamiltonian)
 
     def __sub__(self, hamiltonian: Hamiltonian) -> Hamiltonian:
         return self + (-1.0) * hamiltonian

--- a/psiflow/sampling/ase.py
+++ b/psiflow/sampling/ase.py
@@ -13,7 +13,6 @@ from psiflow.data.utils import write_frames
 from psiflow.geometry import Geometry
 from psiflow.hamiltonians import Hamiltonian
 from psiflow.utils.io import dump_json
-from psiflow.sampling.sampling import serialize_mixture, label_forces
 from psiflow.utils import TMP_COMMAND, CD_COMMAND
 
 from ._ase import ALLOWED_MODES
@@ -79,8 +78,8 @@ def optimize(
 
     input_geometry = Dataset([state]).extxyz
     hamiltonian = 1.0 * hamiltonian  # convert to mixture
-    names, coeffs = label_forces(hamiltonian), hamiltonian.coefficients
-    input_forces = serialize_mixture(hamiltonian, dtype="float64")          # double precision for MLPs
+    names, coeffs = hamiltonian.get_named_components(), hamiltonian.coefficients
+    input_forces = hamiltonian.serialize(dtype="float64")                   # double precision for MLPs
     forces = [
         dict(forcefield=n, weight=str(c), file=f.filename) for n, c, f in zip(names, coeffs, input_forces)
     ]

--- a/psiflow/sampling/output.py
+++ b/psiflow/sampling/output.py
@@ -25,8 +25,7 @@ DEFAULT_OBSERVABLES = [
 
 @typeguard.typechecked
 def potential_component_names(n: int):
-    str_format = "pot_component_raw({})"
-    return [str_format.format(i) + "{electronvolt}" for i in range(n)]
+    return [f'pot_component_raw({i}){{electronvolt}}' for i in range(n)]
 
 
 @typeguard.typechecked

--- a/psiflow/sampling/sampling.py
+++ b/psiflow/sampling/sampling.py
@@ -254,7 +254,7 @@ def setup_system_template(
     start.text = " start_INDEX.xyz "
     initialize.append(start)
     velocities = ET.Element("velocities", mode="thermal", units="kelvin")
-    velocities.text = " TEMP " if " TEMP " in weights_names else " 300 "    # valid template parameter
+    velocities.text = " TEMP " if "TEMP" in weights_names else " 300 "    # valid template parameter
     initialize.append(velocities)
     if walkers[0].masses is not None:
         import ase.units

--- a/psiflow/sampling/sampling.py
+++ b/psiflow/sampling/sampling.py
@@ -44,7 +44,7 @@ class EnsembleTable:
         return self.weights[:, self.keys.index(key)]
 
     def __len__(self) -> int:
-        return len(self.keys)
+        return self.weights.shape[0]
 
     def __eq__(self, other: EnsembleTable) -> bool:
         if (
@@ -275,6 +275,8 @@ def setup_system_template(
     system_template.append(labels)
 
     for i in range(len(ensemble_table)):
+        print(i)
+        print(ensemble_table.get_index(i))
         instance = ET.Element("instance")
         instance.text = create_xml_list([f'{i}'] + [str(w) for w in ensemble_table.get_index(i)])
         system_template.append(instance)

--- a/psiflow/serialization.py
+++ b/psiflow/serialization.py
@@ -14,6 +14,10 @@ from parsl.dataflow.futures import AppFuture
 import psiflow
 from psiflow.geometry import Geometry
 
+
+# TODO: this is only used in the Learning class currently
+
+
 _DataFuture = Union[File, DataFuture]
 
 

--- a/psiflow/serialization.py
+++ b/psiflow/serialization.py
@@ -42,7 +42,7 @@ def create_setter(name, kind, type_hint):
     return setter
 
 
-def update_init(init_func):
+def update_init(init_func):             # TODO: why not have a Mixin class instead?
     def wrapper(self, *args, **kwargs):
         self._geoms = {}
         self._files = {}


### PR DESCRIPTION
In i-Pi REX, force components under the `<forces>` tag are not swapped between replicas. Only force components under the `<bias>` tag can be exchanged (along with ensemble variables).

Here, we check the Hamiltonian of every replica, listing shared components (e.g., `MACEHamiltonian`) under  `<forces>`  and specific components (e.g., umbrella `PlumedHamiltonian`) under `<bias>`.

fixes #87 